### PR TITLE
Improve TestFlight build description format

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -38,12 +38,15 @@ platform :ios do
       commit_info = last_git_commit
       commit_hash = ENV['GITHUB_SHA']&.slice(0, 7) || commit_info[:abbreviated_commit_hash]
       
-      UI.message("📝 Branch: #{branch_name}, Commit: #{commit_hash}")
+      # Get build number
+      build_num = get_build_number(xcodeproj: "CD starter project.xcodeproj")
+      build_date = Time.now.strftime('%b %d, %Y')
       
-      # Build changelog with branch and commit info
-      changelog_text = "Branch: #{branch_name}\n" +
-                      "Commit: #{commit_hash}\n\n" +
-                      "Automated build from CI/CD pipeline"
+      UI.message("📝 Branch: #{branch_name}, Commit: #{commit_hash}, Build: #{build_num}")
+      
+      # Build changelog - concise format
+      changelog_text = "#{branch_name} (#{commit_hash})\n" +
+                      "Build ##{build_num} • #{build_date}"
 
       testflight(
         username: ENV["FASTLANE_USERNAME"],


### PR DESCRIPTION
## Summary
Simplifies the TestFlight build description to a cleaner, more scannable format.

## Changes
- Concise two-line format instead of verbose multi-line
- Branch and commit on first line for quick identification
- Build number and date on second line for reference

## Before
Branch: feature/my-feature
Commit: abc1234
Automated build from CI/CD pipeline
## After
feature/my-feature (abc1234)
Build #27 • Jan 16, 2026